### PR TITLE
Fixing custom depot lock bug

### DIFF
--- a/data/ui_scripts/custom_depot/depot_override.lua
+++ b/data/ui_scripts/custom_depot/depot_override.lua
@@ -319,3 +319,14 @@ MPDepotMenu = function(unk1, unk2)
     return depot_menu
 end
 LUI.MenuBuilder.m_types_build["MPDepotMenu"] = MPDepotMenu
+
+GetLootDataForRef_orig = LUI.InventoryUtils.GetLootDataForRef
+LUI.InventoryUtils.GetLootDataForRef = function(f13_arg0, f13_arg1, f13_arg2, f13_arg3, f13_arg4)
+    local loot_data = GetLootDataForRef_orig(f13_arg0, f13_arg1, f13_arg2, f13_arg3, f13_arg4)
+
+    if loot_data and custom_depot.get_function("has_item")(loot_data.guid) then
+        loot_data.lockState = "Unlocked"
+    end
+
+    return loot_data
+end

--- a/data/ui_scripts/custom_depot/scoreboard_override.lua
+++ b/data/ui_scripts/custom_depot/scoreboard_override.lua
@@ -1,21 +1,7 @@
 -- from roundend.lua, dev comments says that the game["round_end"] array contains indexes for this table
-local ending_reasons = {
-    "MP_DRAW",
-    "LUA_MENU_REPORT_DRAW",
-    "MP_ROUND_WIN",
-    "MP_ROUND_LOSS",
-    "LUA_MENU_REPORT_VICTORY",
-    "LUA_MENU_REPORT_DEFEAT",
-    "MP_HALFTIME",
-    "MP_OVERTIME",
-    "MP_ROUNDEND",
-    "MP_INTERMISSION",
-    "MP_SWITCHING_SIDES",
-    "MP_MATCH_BONUS_IS",
-    "MP_MATCH_TIE",
-    "MP_GAME_END",
-    "SPLASHES_BLANK"
-}
+local ending_reasons = {"MP_DRAW", "LUA_MENU_REPORT_DRAW", "MP_ROUND_WIN", "MP_ROUND_LOSS", "LUA_MENU_REPORT_VICTORY",
+                        "LUA_MENU_REPORT_DEFEAT", "MP_HALFTIME", "MP_OVERTIME", "MP_ROUNDEND", "MP_INTERMISSION",
+                        "MP_SWITCHING_SIDES", "MP_MATCH_BONUS_IS", "MP_MATCH_TIE", "MP_GAME_END", "SPLASHES_BLANK"}
 
 local function starts_with(str, start)
     return str:sub(1, #start) == start


### PR DESCRIPTION
If you craft or loot a camo, it'll be show locked. Now, it's fixed. 
Thanks a lot to @yoyothebest for reporting me the bug!