### PR TITLE
refactor: update checksum and files used on system_check component

### DIFF
--- a/src/client/component/system_check.cpp
+++ b/src/client/component/system_check.cpp
@@ -32,7 +32,7 @@ namespace system_check
 		std::string hash_zone(const std::string& name)
 		{
 			const auto data = read_zone(name);
-			return utils::cryptography::sha256::compute(data, true);
+			return utils::cryptography::md5::compute(data, true);
 		}
 
 		bool verify_hashes(const std::unordered_map<std::string, std::string>& zone_hashes)
@@ -53,15 +53,13 @@ namespace system_check
 		{
 			static std::unordered_map<std::string, std::string> mp_zone_hashes =
 			{
-				{"patch_common_mp.ff", "E45EF5F29D12A5A47F405F89FBBEE479C0A90D02141ABF852D481689514134A1"},
+				{"patch_ui_mp.ff", "A308EE76F49E7FF6B30B33CB37D77282"},
 			};
 
 			static std::unordered_map<std::string, std::string> sp_zone_hashes =
 			{
-				// Steam doesn't necessarily deliver this file :(
-				{"patch_common.ff", "1D32A9770F90ED022AA76F4859B4AB178E194A703383E61AC2CE83B1E828B18F"},
+				{"patch_icbm.ff", "05581F47DC7965C0272D50538A30660A"},
 			};
-
 
 			return verify_hashes(mp_zone_hashes) && (game::environment::is_dedi() || verify_hashes(sp_zone_hashes));
 		}
@@ -103,5 +101,4 @@ namespace system_check
 	};
 }
 
-// TODO: this component needs revised. when it's on, it adds 3+ seconds to the initial load time 
-//REGISTER_COMPONENT(system_check::component)
+REGISTER_COMPONENT(system_check::component)

--- a/src/common/utils/cryptography.cpp
+++ b/src/common/utils/cryptography.cpp
@@ -523,6 +523,26 @@ namespace utils::cryptography
 		return string::dump_hex(hash, "");
 	}
 
+	std::string md5::compute(const std::string& data, const bool hex)
+	{
+		return compute(cs(data.data()), data.size(), hex);
+	}
+
+	std::string md5::compute(const uint8_t* data, const size_t length, const bool hex)
+	{
+		uint8_t buffer[16] = { 0 };
+
+		hash_state state;
+		md5_init(&state);
+		md5_process(&state, data, ul(length));
+		md5_done(&state, buffer);
+
+		std::string hash(cs(buffer), sizeof(buffer));
+		if (!hex) return hash;
+
+		return string::dump_hex(hash, "");
+	}
+
 	std::string sha256::compute(const std::string& data, const bool hex)
 	{
 		return compute(cs(data.data()), data.size(), hex);

--- a/src/common/utils/cryptography.hpp
+++ b/src/common/utils/cryptography.hpp
@@ -84,6 +84,12 @@ namespace utils::cryptography
 		std::string compute(const uint8_t* data, size_t length, bool hex = false);
 	}
 
+	namespace md5
+	{
+		std::string compute(const std::string& data, bool hex = false);
+		std::string compute(const uint8_t* data, size_t length, bool hex = false);
+	}
+
 	namespace sha256
 	{
 		std::string compute(const std::string& data, bool hex = false);


### PR DESCRIPTION
Refactor system_check component to help speed up load times.

SHA256 -> 2700ms
MD5 -> 186ms

<img width="685" height="33" alt="image" src="https://github.com/user-attachments/assets/31354e3a-b0dc-444b-b506-f073f9557b1d" />

Updated files used to perform checksum and ensured these are shipped with the correct steam depot

Targets #1053 
